### PR TITLE
feat: synthesizer pickle 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+api_server/synthesizer.pickle
 .erlang.cookie
 mnesia/
 voicepocket-bucketKey.json

--- a/api_server/tts_process.py
+++ b/api_server/tts_process.py
@@ -1,4 +1,4 @@
-import os, sys, tarfile
+import os, sys, tarfile, pickle
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 
 from module.TTS.TTS.utils.synthesizer import Synthesizer
@@ -32,7 +32,10 @@ def add_synth(email):
     )
 
     synth_dict[email] = synthesizer
-
+    
+    with open("./api_server/synthesizer.pickle","wb") as fw:
+        pickle.dump(synth_dict, fw)
+    
     # os.remove(voice_model_path)
 
 def make_tts(email, uuid, text):
@@ -47,4 +50,7 @@ def make_tts(email, uuid, text):
     
     os.remove(wav_path)
 
-synth_dict = {} # syntesizer 객체를 모아두는 딕셔너리
+synth_dict = {}
+
+with open("./api_server/synthesizer.pickle","rb") as fr:
+    synth_dict = pickle.load(fr)


### PR DESCRIPTION
synthesizer 객체를 pickle 파일로 만들어 관리하는 코드를 추가했습니다.

+ 
신 버전 coqui-tts는 코드의 수정이 많이 필요할 것 같아, 일단 구 버전 기준으로 pickle을 적용했습니다.
synthesizer.pickle 파일은 개인적인 정보이므로 gitignore에 추가해두었습니다.